### PR TITLE
design: 작성 완료 버튼 제작

### DIFF
--- a/src/components/CompleteBtn/CompleteBtn.style.ts
+++ b/src/components/CompleteBtn/CompleteBtn.style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const StyledButton = styled.button<{ disabled?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: ${({ theme }) => theme.fonts.medium500};
+  color: ${({ disabled }) => (disabled ? '#979C9E' : '#198155')};
+  background-color: ${({ disabled }) => (disabled ? '#e3e5e5' : '#ECFCE5')};
+  height: 48px;
+  width: 330px;
+  border: none;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+`;

--- a/src/components/CompleteBtn/CompleteBtn.tsx
+++ b/src/components/CompleteBtn/CompleteBtn.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { StyledButton } from './CompleteBtn.style';
+
+interface ButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+export const CompleteBtn = ({ children, onClick, disabled = false }: ButtonProps) => {
+  return (
+    <StyledButton onClick={onClick} disabled={disabled}>
+      {children}
+    </StyledButton>
+  );
+};


### PR DESCRIPTION
## 📢 기능 설명

작성 완료 버튼을 공통 컴포넌트 형식으로 제작했습니다.

https://github.com/user-attachments/assets/bdb0c898-d883-4a27-a5ce-4314c40aa87e

내 집주소...

`onClick`과 `disabled` 속성을 받아서 클릭 이벤트와 비활성화 상태를 제어하도록 했습니다.

보통 공통 컴포넌트나 디자인 시스템에서 props로 width, fontsize, colortype등을 받는데 
이 프로젝트 디자인에는 필요 없을 것 같아서 다 제외하고 

```ts
interface ButtonProps {
  children: React.ReactNode;
  onClick?: () => void;
  disabled?: boolean;
}
```
이렇게만 받습니다.

사용 예시는 다음과 같습니다.
사용자가 모든 폼을 다 채웠을 때 버튼이 활성화(disabled가 false에서 true로 바뀜)되도록 구현한 예시입니다.
```ts
import React, { useState } from 'react';

import { useNavigate } from 'react-router-dom';

import { CompleteBtn } from '@/components/CompleteBtn/CompleteBtn';

export const Home = () => {
  const navigate = useNavigate();

  const [formData, setFormData] = useState({
    name: '',
    email: '',
    address: '',
  });

  const isFormComplete = formData.name && formData.email && formData.address;

  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    const { name, value } = e.target;
    setFormData((prevData) => ({
      ...prevData,
      [name]: value,
    }));
  };

  const handleComplete = () => {
    if (isFormComplete) {
      navigate('/mypage');
    }
  };

  return (
    <div>
      <h1>폼 작성</h1>
      <form>
        <div>
          <label>이름:</label>
          <input type="text" name="name" value={formData.name} onChange={handleChange} />
        </div>
        <div>
          <label>이메일:</label>
          <input type="email" name="email" value={formData.email} onChange={handleChange} />
        </div>
        <div>
          <label>주소:</label>
          <input type="text" name="address" value={formData.address} onChange={handleChange} />
        </div>
      </form>

      {/* 모든 폼이 채워졌을 때 버튼 활성화 */}
      <CompleteBtn onClick={handleComplete} disabled={!isFormComplete}>
        작성 완료
      </CompleteBtn>
    </div>
  );
};
```

## 연결된 issue
close #4 

## 🩷 Approve 하기 전 확인해주세요!
<img width="1240" alt="스크린샷 2024-10-08 오후 2 26 39" src="https://github.com/user-attachments/assets/f6074376-28b0-451e-94bb-41f81d992c49">
지금 에러 뜨는데 main에서는 잘 됩니다... 죄송...

## ✅ 체크리스트

- [X] PR 제목 규칙 잘 지켰는가?
- [X] 추가/수정사항을 설명하였는가?
- [X] 이슈넘버를 적었는가?
- [X] Approve 하기 전 확인 사항 체크했는가?
