### PR TITLE
fix: BottomSheet 컴포넌트 prop 추가

### DIFF
--- a/src/components/BottomSheet/BottomSheet.style.ts
+++ b/src/components/BottomSheet/BottomSheet.style.ts
@@ -1,7 +1,9 @@
 import { motion } from 'framer-motion';
 import { styled } from 'styled-components';
 
-export const StyledBottomSheet = styled(motion.div)<{ height: number }>`
+export const StyledBottomSheet = styled(motion.div)<{ height: number; $zIndex: number }>`
+  display: flex;
+  flex-direction: column;
   position: absolute;
   bottom: 0;
   left: 0;
@@ -12,8 +14,11 @@ export const StyledBottomSheet = styled(motion.div)<{ height: number }>`
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
   overflow: visible;
+  z-index: ${({ $zIndex }) => $zIndex || 0};
 `;
 
 export const ContentContainer = styled.div`
+  flex: 1;
   padding-top: 24px;
+  overflow: hidden;
 `;

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -10,6 +10,7 @@ interface BottomSheetProps {
   maxHeight?: number;
   showHeader?: boolean;
   children: ReactNode;
+  $zIndex?: number;
 }
 
 export const BottomSheet = ({
@@ -18,11 +19,12 @@ export const BottomSheet = ({
   maxHeight = window.innerHeight * 0.57,
   showHeader = true,
   children,
+  $zIndex = 0,
 }: BottomSheetProps) => {
   const { sheet, content, height } = useBottomSheet(initialHeight, minHeight, maxHeight);
 
   return (
-    <StyledBottomSheet ref={sheet} height={height}>
+    <StyledBottomSheet ref={sheet} height={height} $zIndex={$zIndex}>
       <ContentContainer ref={content}>
         {showHeader && <BottomSheetHeader />}
         {children}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #67 
<br>


## 🩷 Approve 하기 전 확인해주세요!


https://github.com/user-attachments/assets/b409eb63-2212-407b-a9c1-f969ae4d442e



이렇게 필터 바텀시트는 탭바 위에 올라오게 하기 위해서 수정했습니다!
prop에 $z-index 추가했습니다~

추후에 안에 담는 페이지들을 위해 flex랑 overflow 추가했습니다~
``` 
export const ContentContainer = styled.div`
  flex: 1;
  padding-top: 24px;
  overflow: hidden;
`;

```

- [x]  BottomSheet 컴포넌트 prop 추가
- [x] BottomSheet 컴포넌트 style 조금 수정
  <br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
