### PR TITLE
fix: 지도 컴포넌트 바운더리 함수 추가

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -27,8 +27,11 @@ declare namespace naver.maps {
   }
 
   class LatLngBounds {
+    constructor(sw?: LatLng, ne?: LatLng);
     extend: (latlng: LatLng) => void;
     getCenter: () => LatLng;
+    getSW: () => LatLng;
+    getNE: () => LatLng;
   }
 
   interface MarkerOptions {


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

https://github.com/user-attachments/assets/3d8921c2-40a7-4937-a57f-4d90d0942932


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #74 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x]  updateMapBounds() 함수 추가
1. 지도 리스트로 마커 여러개 찍으면 -> 화면안에 마커가 다 들어오게 바운더리 설정
2. 바텀시트 밖에 마커 다 보일 수 있게, 바운더리 위도 경도 수정

- 여러 개 피커 중에 피커 하나 고르시 줌인
- 해당 피커 재클릭시 줌아웃
- 화면의 다른 부분 클릭시 바텀 시트만 내려가고, 근처 지도 살펴볼 수 있게 줌아웃 안함
  <br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
